### PR TITLE
イメージ提供方法の変更・テスト実施の条件変更

### DIFF
--- a/.github/workflows/classroom.yml
+++ b/.github/workflows/classroom.yml
@@ -1,7 +1,17 @@
 name: Autograding Tests
 'on':
-- push
-- repository_dispatch
+  push:
+    paths:
+      - "app/**"
+      - "public/**"
+      - "resources/**"
+      - "routes/**"
+      - "tests/**"
+      - "config/**"
+
+# ダミーの環境変数定義(赤波線対策)
+env:
+
 permissions:
   checks: write
   actions: read

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -44,7 +44,7 @@ jobs:
             # latestタグも追加
             flavor: |
                 latest=${{ github.ref == 'refs/heads/main' }}
-                epoch=${{ steps.epoch.outputs.epoch }}
+                ${{ steps.epoch.outputs.epoch }}
         - name: Dockerイメージのビルド
           uses: docker/build-push-action@v4
           with:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -58,6 +58,7 @@ jobs:
             context: docker/web
             file: ./Dockerfile
             push: false
+            load: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}
             platforms: linux/amd64,linux/arm64

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -12,6 +12,8 @@ on:
         paths:
             - 'docker/web/**'
             - 'docker/app/**'
+            - '.github/workflows/ghcr.yml'
+    # 手動で実行する場合
     workflow_dispatch:
 
 env:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,56 @@
+# docker/webもしくはdocker/app以下の更新があったときに、
+# それぞれのDockerfileを使ってビルドし直す
+# 各イメージについては、以下のベース名を持つ
+# docker/web -> ghcr.io/densuke/laravelapp-web
+# docker/app -> ghcr.io/densuke/laravelapp-web
+# それぞれタグとして、ビルド時のepoch秒を設定する、これは人によりイメージが異なることを防ぐためである
+
+name: image CI
+on:
+    # ディレクトリdocker/webとdocker/appに変更があったときに実行
+    push:
+        paths:
+            - 'docker/web/**'
+            - 'docker/app/**'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+    build-web:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+        - name: ソース取得
+          uses: actions/checkout@v4
+        - name: コンテナレジストリへのログイン
+          uses: docker/login-action@v3
+          with:
+                registry: ${{ env.REGISTRY }}
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+        - name: 現在時刻のEpoch秒を取得してタグに利用
+          id: epoch
+          run: echo "::set-output name=epoch::$(date +%s)"
+        - name: メタデータの取得(Docker)
+          id: meta
+          uses: docker/metadata-action@v4
+          with:
+            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            # latestタグも追加
+            flavor: |
+                latest=${{ github.ref == 'refs/heads/main' }}
+                epoch=${{ steps.epoch.outputs.epoch }}
+        - name: Dockerイメージのビルド
+          uses: docker/build-push-action@v4
+          with:
+            context: docker/web
+            file: ./Dockerfile
+            push: false
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            platforms: linux/amd64,linux/arm64
+            provenance: false

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -56,7 +56,7 @@ jobs:
           uses: docker/build-push-action@v4
           with:
             context: docker/web
-            file: ./Dockerfile
+            #file: ./Dockerfile
             push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -57,8 +57,7 @@ jobs:
           with:
             context: docker/web
             file: ./Dockerfile
-            push: false
-            load: true
+            push: true
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}
             platforms: linux/amd64,linux/arm64

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -44,6 +44,9 @@ jobs:
             # latestタグも追加
             flavor: |
                 latest=${{ github.ref == 'refs/heads/main' }}
+                # ${{ steps.epoch.outputs.epoch }}
+            # タグとして先程取得したepochの値を設定
+            tags: |
                 ${{ steps.epoch.outputs.epoch }}
         - name: Dockerイメージのビルド
           uses: docker/build-push-action@v4

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -12,6 +12,7 @@ on:
         paths:
             - 'docker/web/**'
             - 'docker/app/**'
+    workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -48,6 +48,8 @@ jobs:
             # タグとして先程取得したepochの値を設定
             tags: |
                 ${{ steps.epoch.outputs.epoch }}
+        - name: Docker Buildxのセットアップ
+          uses: docker/setup-buildx-action@v3
         - name: Dockerイメージのビルド
           uses: docker/build-push-action@v4
           with:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -42,7 +42,7 @@ jobs:
           id: meta
           uses: docker/metadata-action@v4
           with:
-            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/web
             # latestタグも追加
             flavor: |
                 latest=${{ github.ref == 'refs/heads/main' }}
@@ -62,3 +62,44 @@ jobs:
             labels: ${{ steps.meta.outputs.labels }}
             platforms: linux/amd64,linux/arm64
             provenance: false
+    build-app:
+      runs-on: ubuntu-latest
+      permissions:
+          contents: read
+          packages: write
+      steps:
+      - name: ソース取得
+        uses: actions/checkout@v4
+      - name: コンテナレジストリへのログイン
+        uses: docker/login-action@v3
+        with:
+              registry: ${{ env.REGISTRY }}
+              username: ${{ github.actor }}
+              password: ${{ secrets.GITHUB_TOKEN }}
+      - name: 現在時刻のEpoch秒を取得してタグに利用
+        id: epoch
+        run: echo "::set-output name=epoch::$(date +%s)"
+      - name: メタデータの取得(Docker)
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/app
+          # latestタグも追加
+          flavor: |
+              latest=${{ github.ref == 'refs/heads/main' }}
+              # ${{ steps.epoch.outputs.epoch }}
+          # タグとして先程取得したepochの値を設定
+          tags: |
+              ${{ steps.epoch.outputs.epoch }}
+      - name: Docker Buildxのセットアップ
+        uses: docker/setup-buildx-action@v3
+      - name: Dockerイメージのビルド
+        uses: docker/build-push-action@v4
+        with:
+          context: docker/app
+          #file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false

--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,8 @@
 services:
   web:
-    #image: nginx:alpine
-    build: docker/web
+    image: ghcr.io/kd-it/laravel-minishop/web:1727734669
+
+    #build: docker/web
     volumes:
       - .:/app:cached
     env_file:
@@ -11,8 +12,8 @@ services:
       - db
 
   app:
-    #image: php:fpm-alpine
-    build: docker/app
+    image: ghcr.io/kd-it/laravel-minishop/app:1727734667
+    #build: docker/app
     env_file:
       - env.txt
     volumes:

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -20,15 +20,19 @@ RUN apk add --no-cache \
 # RUN pecl install xdebug \
 #     && docker-php-ext-enable xdebug
 RUN docker-php-ext-install mysqli pdo_mysql
-
+# やはりbashは最低限必要ですね
+RUN apk add --no-cache bash bash-completion
 # 作業用ユーザーの作成、シェルは/bin/sh
 RUN addgroup -g $USER_GID $USERNAME \
-    && adduser -u $USER_UID -G $USERNAME -s /bin/sh -D $USERNAME
+    && adduser -u $USER_UID -G $USERNAME -s /bin/bash -D $USERNAME
 # $USERNAMEにはsudo権限を付与
 RUN echo "$USERNAME ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$USERNAME
 # composerのラッパーをインストール
 COPY composer /usr/local/bin/composer
 RUN chmod 755 /usr/local/bin/composer
+# シェル補完用の設定を追加
+RUN cd /usr/share/bash-completion/completions; \
+    composer completion bash > composer
 USER ${USERNAME}
 ENV PATH="/home/${USERNAME}/.composer/vendor/bin:/home/${USERNAME}/.local/bin:${PATH}"
 WORKDIR /app


### PR DESCRIPTION
イメージの提供方法をbuildからimageに変更しました、毎度ビルドしなくて済むので少し利用の敷居が下がると思います。
- Dockerイメージの生成
- ghcrへのpush
- `compose.yml`においてイメージ利用に設定を変更

また、Classroomでの評価については該当するディレクトリの変更のみ反応するようにしましたが、
よくよく考えればこのファイル、github classroom内で適当に作ってしまう(差し替えてしまう)ためあまり意味がないかもしれません。

今後イメージビルドはmatrix buildを用いたarch別並列化に切り替えるかもしれません(タグ名を揃えるなども含まれることになります)。